### PR TITLE
feat: add discipline entity to group subjects for study cycles

### DIFF
--- a/backend/prisma/migrations/20260203000000_add_discipline_entity/migration.sql
+++ b/backend/prisma/migrations/20260203000000_add_discipline_entity/migration.sql
@@ -1,0 +1,43 @@
+-- CreateTable
+CREATE TABLE "disciplines" (
+    "id" TEXT NOT NULL,
+    "workspace_id" TEXT NOT NULL,
+    "name" VARCHAR(100) NOT NULL,
+    "color" VARCHAR(7),
+    "icon" VARCHAR(50),
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "disciplines_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable: Add discipline_id to subjects
+ALTER TABLE "subjects" ADD COLUMN "discipline_id" TEXT;
+
+-- AlterTable: Make subject_id nullable in study_cycle_items
+ALTER TABLE "study_cycle_items" ALTER COLUMN "subject_id" DROP NOT NULL;
+
+-- AlterTable: Add discipline_id to study_cycle_items
+ALTER TABLE "study_cycle_items" ADD COLUMN "discipline_id" TEXT;
+
+-- CreateIndex
+CREATE INDEX "disciplines_workspace_id_idx" ON "disciplines"("workspace_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "disciplines_workspace_id_name_key" ON "disciplines"("workspace_id", "name");
+
+-- CreateIndex
+CREATE INDEX "subjects_discipline_id_idx" ON "subjects"("discipline_id");
+
+-- CreateIndex
+CREATE INDEX "study_cycle_items_discipline_id_idx" ON "study_cycle_items"("discipline_id");
+
+-- AddForeignKey
+ALTER TABLE "disciplines" ADD CONSTRAINT "disciplines_workspace_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "subjects" ADD CONSTRAINT "subjects_discipline_id_fkey" FOREIGN KEY ("discipline_id") REFERENCES "disciplines"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "study_cycle_items" ADD CONSTRAINT "study_cycle_items_discipline_id_fkey" FOREIGN KEY ("discipline_id") REFERENCES "disciplines"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -117,26 +117,49 @@ model Workspace {
   examProfiles  ExamProfile[]
   subjects      Subject[]
   categories    Category[]
+  disciplines   Discipline[]
 
   @@unique([userId, name])
   @@index([userId])
   @@map("workspaces")
 }
 
+// Discipline - groups related subjects for study cycle organization
+model Discipline {
+  id          String   @id @default(cuid())
+  workspaceId String   @map("workspace_id")
+  name        String   @db.VarChar(100)
+  color       String?  @db.VarChar(7)
+  icon        String?  @db.VarChar(50)
+  position    Int      @default(0)
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  workspace       Workspace        @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  subjects        Subject[]
+  studyCycleItems StudyCycleItem[]
+
+  @@unique([workspaceId, name])
+  @@index([workspaceId])
+  @@map("disciplines")
+}
+
 // Subject - normalized subjects per workspace
 model Subject {
-  id          String    @id @default(cuid())
-  workspaceId String    @map("workspace_id")
-  name        String    @db.VarChar(100)
-  color       String?   @db.VarChar(7)
-  icon        String?   @db.VarChar(50)
-  category    String?   @db.VarChar(50) // @deprecated - use categories relation
-  position    Int       @default(0)
-  archivedAt  DateTime? @map("archived_at")
-  createdAt   DateTime  @default(now()) @map("created_at")
-  updatedAt   DateTime  @updatedAt @map("updated_at")
+  id           String    @id @default(cuid())
+  workspaceId  String    @map("workspace_id")
+  disciplineId String?   @map("discipline_id")
+  name         String    @db.VarChar(100)
+  color        String?   @db.VarChar(7)
+  icon         String?   @db.VarChar(50)
+  category     String?   @db.VarChar(50) // @deprecated - use categories relation
+  position     Int       @default(0)
+  archivedAt   DateTime? @map("archived_at")
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime  @updatedAt @map("updated_at")
 
   workspace        Workspace         @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  discipline       Discipline?       @relation(fields: [disciplineId], references: [id], onDelete: SetNull)
   studySessions    StudySession[]
   studyCycleItems  StudyCycleItem[]
   subjectProfiles  SubjectProfile[]
@@ -144,6 +167,7 @@ model Subject {
 
   @@unique([workspaceId, name])
   @@index([workspaceId])
+  @@index([disciplineId])
   @@index([category])
   @@map("subjects")
 }
@@ -270,21 +294,25 @@ model StudyCycle {
   @@map("study_cycles")
 }
 
-// Study Cycle Item - individual subject entry in a cycle
+// Study Cycle Item - individual subject or discipline entry in a cycle
+// Either subjectId OR disciplineId must be set (validated in application layer)
 model StudyCycleItem {
-  id                  String @id @default(cuid())
-  cycleId             String @map("cycle_id")
-  subjectId           String @map("subject_id")
-  targetMinutes       Int    @map("target_minutes")
+  id                  String  @id @default(cuid())
+  cycleId             String  @map("cycle_id")
+  subjectId           String? @map("subject_id")
+  disciplineId        String? @map("discipline_id")
+  targetMinutes       Int     @map("target_minutes")
   position            Int
-  compensationMinutes Int    @default(0) @map("compensation_minutes") // Minutes added when skipping incomplete
+  compensationMinutes Int     @default(0) @map("compensation_minutes") // Minutes added when skipping incomplete
 
-  cycle   StudyCycle @relation(fields: [cycleId], references: [id], onDelete: Cascade)
-  subject Subject    @relation(fields: [subjectId], references: [id], onDelete: Cascade)
+  cycle      StudyCycle  @relation(fields: [cycleId], references: [id], onDelete: Cascade)
+  subject    Subject?    @relation(fields: [subjectId], references: [id], onDelete: Cascade)
+  discipline Discipline? @relation(fields: [disciplineId], references: [id], onDelete: Cascade)
 
   @@unique([cycleId, position])
   @@index([cycleId])
   @@index([subjectId])
+  @@index([disciplineId])
   @@map("study_cycle_items")
 }
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -19,6 +19,7 @@ import { ExamTemplateModule } from './exam-template/exam-template.module';
 import { ExamProfileModule } from './exam-profile/exam-profile.module';
 import { SubjectModule } from './subject/subject.module';
 import { CategoryModule } from './category/category.module';
+import { DisciplineModule } from './discipline/discipline.module';
 
 @Module({
   imports: [
@@ -72,6 +73,7 @@ import { CategoryModule } from './category/category.module';
     ExamProfileModule,
     SubjectModule,
     CategoryModule,
+    DisciplineModule,
   ],
   providers: [
     {

--- a/backend/src/discipline/discipline.controller.ts
+++ b/backend/src/discipline/discipline.controller.ts
@@ -1,0 +1,121 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+} from '@nestjs/common';
+import { Session } from '@thallesp/nestjs-better-auth';
+import type { UserSession } from '@thallesp/nestjs-better-auth';
+import { DisciplineService } from './discipline.service';
+import { CreateDisciplineDto, UpdateDisciplineDto } from './dto';
+
+@Controller('api')
+export class DisciplineController {
+  constructor(private disciplineService: DisciplineService) {}
+
+  /**
+   * GET /api/workspaces/:workspaceId/disciplines
+   * Lista todas as disciplinas do workspace
+   */
+  @Get('workspaces/:workspaceId/disciplines')
+  async findAll(
+    @Session() session: UserSession,
+    @Param('workspaceId') workspaceId: string,
+  ) {
+    const userId = session.user.id;
+    return this.disciplineService.findAll(userId, workspaceId);
+  }
+
+  /**
+   * POST /api/workspaces/:workspaceId/disciplines
+   * Cria uma nova disciplina
+   */
+  @Post('workspaces/:workspaceId/disciplines')
+  async create(
+    @Session() session: UserSession,
+    @Param('workspaceId') workspaceId: string,
+    @Body() dto: CreateDisciplineDto,
+  ) {
+    const userId = session.user.id;
+    return this.disciplineService.create(userId, workspaceId, dto);
+  }
+
+  /**
+   * GET /api/disciplines/:id
+   * Busca uma disciplina por ID
+   */
+  @Get('disciplines/:id')
+  async findOne(@Session() session: UserSession, @Param('id') id: string) {
+    const userId = session.user.id;
+    return this.disciplineService.findOne(userId, id);
+  }
+
+  /**
+   * PUT /api/disciplines/:id
+   * Atualiza uma disciplina
+   */
+  @Put('disciplines/:id')
+  async update(
+    @Session() session: UserSession,
+    @Param('id') id: string,
+    @Body() dto: UpdateDisciplineDto,
+  ) {
+    const userId = session.user.id;
+    return this.disciplineService.update(userId, id, dto);
+  }
+
+  /**
+   * POST /api/disciplines/:id/subjects
+   * Adiciona subjects a uma disciplina
+   */
+  @Post('disciplines/:id/subjects')
+  async addSubjects(
+    @Session() session: UserSession,
+    @Param('id') id: string,
+    @Body() body: { subjectIds: string[] },
+  ) {
+    const userId = session.user.id;
+    return this.disciplineService.addSubjects(userId, id, body.subjectIds);
+  }
+
+  /**
+   * DELETE /api/disciplines/:id/subjects
+   * Remove subjects de uma disciplina
+   */
+  @Delete('disciplines/:id/subjects')
+  async removeSubjects(
+    @Session() session: UserSession,
+    @Param('id') id: string,
+    @Body() body: { subjectIds: string[] },
+  ) {
+    const userId = session.user.id;
+    return this.disciplineService.removeSubjects(userId, id, body.subjectIds);
+  }
+
+  /**
+   * PUT /api/workspaces/:workspaceId/disciplines/reorder
+   * Reordena as disciplinas
+   */
+  @Put('workspaces/:workspaceId/disciplines/reorder')
+  async reorder(
+    @Session() session: UserSession,
+    @Param('workspaceId') workspaceId: string,
+    @Body() body: { orderedIds: string[] },
+  ) {
+    const userId = session.user.id;
+    return this.disciplineService.reorder(userId, workspaceId, body.orderedIds);
+  }
+
+  /**
+   * DELETE /api/disciplines/:id
+   * Deleta uma disciplina
+   */
+  @Delete('disciplines/:id')
+  async delete(@Session() session: UserSession, @Param('id') id: string) {
+    const userId = session.user.id;
+    return this.disciplineService.delete(userId, id);
+  }
+}

--- a/backend/src/discipline/discipline.module.ts
+++ b/backend/src/discipline/discipline.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { DisciplineController } from './discipline.controller';
+import { DisciplineService } from './discipline.service';
+
+@Module({
+  controllers: [DisciplineController],
+  providers: [DisciplineService],
+  exports: [DisciplineService],
+})
+export class DisciplineModule {}

--- a/backend/src/discipline/discipline.service.ts
+++ b/backend/src/discipline/discipline.service.ts
@@ -1,0 +1,278 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  ConflictException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateDisciplineDto, UpdateDisciplineDto } from './dto';
+
+@Injectable()
+export class DisciplineService {
+  constructor(private prisma: PrismaService) {}
+
+  /**
+   * Lista todas as disciplinas de um workspace
+   */
+  async findAll(userId: string, workspaceId: string) {
+    await this.verifyWorkspaceAccess(userId, workspaceId);
+
+    return this.prisma.discipline.findMany({
+      where: { workspaceId },
+      orderBy: { position: 'asc' },
+      include: {
+        subjects: {
+          where: { archivedAt: null },
+          orderBy: { position: 'asc' },
+          select: {
+            id: true,
+            name: true,
+            color: true,
+            icon: true,
+          },
+        },
+        _count: {
+          select: { subjects: true },
+        },
+      },
+    });
+  }
+
+  /**
+   * Busca uma disciplina por ID
+   */
+  async findOne(userId: string, disciplineId: string) {
+    const discipline = await this.prisma.discipline.findUnique({
+      where: { id: disciplineId },
+      include: {
+        workspace: true,
+        subjects: {
+          where: { archivedAt: null },
+          orderBy: { position: 'asc' },
+        },
+        _count: {
+          select: { subjects: true },
+        },
+      },
+    });
+
+    if (!discipline) {
+      throw new NotFoundException('Discipline not found');
+    }
+
+    if (discipline.workspace.userId !== userId) {
+      throw new ForbiddenException('Not authorized to access this discipline');
+    }
+
+    return discipline;
+  }
+
+  /**
+   * Cria uma nova disciplina
+   */
+  async create(userId: string, workspaceId: string, dto: CreateDisciplineDto) {
+    await this.verifyWorkspaceAccess(userId, workspaceId);
+
+    // Check for duplicate name in workspace
+    const existing = await this.prisma.discipline.findUnique({
+      where: {
+        workspaceId_name: { workspaceId, name: dto.name },
+      },
+    });
+
+    if (existing) {
+      throw new ConflictException('Discipline with this name already exists');
+    }
+
+    // Get max position if not provided
+    let position = dto.position;
+    if (position === undefined) {
+      const maxPosition = await this.prisma.discipline.aggregate({
+        where: { workspaceId },
+        _max: { position: true },
+      });
+      position = (maxPosition._max.position ?? -1) + 1;
+    }
+
+    // Create discipline and optionally link subjects
+    const discipline = await this.prisma.$transaction(async (tx) => {
+      const created = await tx.discipline.create({
+        data: {
+          workspaceId,
+          name: dto.name,
+          color: dto.color,
+          icon: dto.icon,
+          position,
+        },
+      });
+
+      // Link subjects if provided
+      if (dto.subjectIds && dto.subjectIds.length > 0) {
+        await tx.subject.updateMany({
+          where: {
+            id: { in: dto.subjectIds },
+            workspaceId,
+          },
+          data: {
+            disciplineId: created.id,
+          },
+        });
+      }
+
+      return created;
+    });
+
+    // Return with subjects populated
+    return this.findOne(userId, discipline.id);
+  }
+
+  /**
+   * Atualiza uma disciplina
+   */
+  async update(userId: string, disciplineId: string, dto: UpdateDisciplineDto) {
+    const discipline = await this.findOne(userId, disciplineId);
+
+    // If changing name, check for duplicates
+    if (dto.name && dto.name !== discipline.name) {
+      const existing = await this.prisma.discipline.findUnique({
+        where: {
+          workspaceId_name: {
+            workspaceId: discipline.workspaceId,
+            name: dto.name,
+          },
+        },
+      });
+
+      if (existing && existing.id !== disciplineId) {
+        throw new ConflictException('Discipline with this name already exists');
+      }
+    }
+
+    // Update discipline and subjects in transaction
+    await this.prisma.$transaction(async (tx) => {
+      // Update discipline fields
+      await tx.discipline.update({
+        where: { id: disciplineId },
+        data: {
+          name: dto.name,
+          color: dto.color,
+          icon: dto.icon,
+          position: dto.position,
+        },
+      });
+
+      // If subjectIds is provided, update subject assignments
+      if (dto.subjectIds !== undefined) {
+        // Remove all subjects from this discipline
+        await tx.subject.updateMany({
+          where: { disciplineId },
+          data: { disciplineId: null },
+        });
+
+        // Add specified subjects to this discipline
+        if (dto.subjectIds.length > 0) {
+          await tx.subject.updateMany({
+            where: {
+              id: { in: dto.subjectIds },
+              workspaceId: discipline.workspaceId,
+            },
+            data: { disciplineId },
+          });
+        }
+      }
+    });
+
+    return this.findOne(userId, disciplineId);
+  }
+
+  /**
+   * Adiciona subjects a uma disciplina
+   */
+  async addSubjects(
+    userId: string,
+    disciplineId: string,
+    subjectIds: string[],
+  ) {
+    const discipline = await this.findOne(userId, disciplineId);
+
+    await this.prisma.subject.updateMany({
+      where: {
+        id: { in: subjectIds },
+        workspaceId: discipline.workspaceId,
+      },
+      data: { disciplineId },
+    });
+
+    return this.findOne(userId, disciplineId);
+  }
+
+  /**
+   * Remove subjects de uma disciplina
+   */
+  async removeSubjects(
+    userId: string,
+    disciplineId: string,
+    subjectIds: string[],
+  ) {
+    await this.findOne(userId, disciplineId);
+
+    await this.prisma.subject.updateMany({
+      where: {
+        id: { in: subjectIds },
+        disciplineId,
+      },
+      data: { disciplineId: null },
+    });
+
+    return this.findOne(userId, disciplineId);
+  }
+
+  /**
+   * Deleta uma disciplina
+   * Os subjects terão disciplineId setado para null (OnDelete: SetNull)
+   */
+  async delete(userId: string, disciplineId: string) {
+    await this.findOne(userId, disciplineId);
+
+    return this.prisma.discipline.delete({
+      where: { id: disciplineId },
+    });
+  }
+
+  /**
+   * Reordena as disciplinas
+   */
+  async reorder(
+    userId: string,
+    workspaceId: string,
+    orderedIds: string[],
+  ) {
+    await this.verifyWorkspaceAccess(userId, workspaceId);
+
+    await this.prisma.$transaction(
+      orderedIds.map((id, index) =>
+        this.prisma.discipline.update({
+          where: { id },
+          data: { position: index },
+        }),
+      ),
+    );
+
+    return this.findAll(userId, workspaceId);
+  }
+
+  /**
+   * Helper: verifica se o workspace pertence ao usuario
+   */
+  private async verifyWorkspaceAccess(userId: string, workspaceId: string) {
+    const workspace = await this.prisma.workspace.findFirst({
+      where: { id: workspaceId, userId },
+    });
+
+    if (!workspace) {
+      throw new ForbiddenException('Invalid workspace');
+    }
+
+    return workspace;
+  }
+}

--- a/backend/src/discipline/dto/create-discipline.dto.ts
+++ b/backend/src/discipline/dto/create-discipline.dto.ts
@@ -1,0 +1,39 @@
+import {
+  IsNotEmpty,
+  IsString,
+  IsOptional,
+  MaxLength,
+  Matches,
+  IsInt,
+  Min,
+  IsArray,
+} from 'class-validator';
+
+export class CreateDisciplineDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  @Matches(/^#[0-9A-Fa-f]{6}$/, {
+    message: 'color must be a valid hex color (e.g., #FFFFFF)',
+  })
+  color?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  icon?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  position?: number;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  subjectIds?: string[];
+}

--- a/backend/src/discipline/dto/index.ts
+++ b/backend/src/discipline/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './create-discipline.dto';
+export * from './update-discipline.dto';

--- a/backend/src/discipline/dto/update-discipline.dto.ts
+++ b/backend/src/discipline/dto/update-discipline.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateDisciplineDto } from './create-discipline.dto';
+
+export class UpdateDisciplineDto extends PartialType(CreateDisciplineDto) {}

--- a/backend/src/study-cycle/dto/create-study-cycle.dto.ts
+++ b/backend/src/study-cycle/dto/create-study-cycle.dto.ts
@@ -9,12 +9,20 @@ import {
   Max,
   MaxLength,
   ArrayMinSize,
+  ValidateIf,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class CreateCycleItemDto {
+  @IsOptional()
   @IsString()
-  subjectId: string;
+  @ValidateIf((o) => !o.disciplineId)
+  subjectId?: string;
+
+  @IsOptional()
+  @IsString()
+  @ValidateIf((o) => !o.subjectId)
+  disciplineId?: string;
 
   @IsInt()
   @Min(1)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { SettingsPage } from '@/views/SettingsPage';
 import { ScratchpadPage } from '@/views/ScratchpadPage';
 import { AllocationPage } from '@/views/AllocationPage';
 import { SubjectsPage } from '@/views/SubjectsPage';
+import { DisciplinesPage } from '@/views/DisciplinesPage';
 import { TermsPage } from '@/views/TermsPage';
 import { PrivacyPage } from '@/views/PrivacyPage';
 
@@ -54,6 +55,7 @@ function App() {
           <Route path="scratchpad" element={<ScratchpadPage />} />
           <Route path="allocation" element={<AllocationPage />} />
           <Route path="subjects" element={<SubjectsPage />} />
+          <Route path="disciplines" element={<DisciplinesPage />} />
         </Route>
 
         {/* Landing page */}

--- a/frontend/src/components/SpaApp.tsx
+++ b/frontend/src/components/SpaApp.tsx
@@ -17,6 +17,7 @@ import { SettingsPage } from '@/views/SettingsPage';
 import { ScratchpadPage } from '@/views/ScratchpadPage';
 import { AllocationPage } from '@/views/AllocationPage';
 import { SubjectsPage } from '@/views/SubjectsPage';
+import { DisciplinesPage } from '@/views/DisciplinesPage';
 
 // Toast notifications
 import { Toaster } from '@/components/ui/toaster';
@@ -47,6 +48,7 @@ export function SpaApp() {
           <Route path="scratchpad" element={<ScratchpadPage />} />
           <Route path="allocation" element={<AllocationPage />} />
           <Route path="subjects" element={<SubjectsPage />} />
+          <Route path="disciplines" element={<DisciplinesPage />} />
         </Route>
 
         {/* Redirect unknown routes to app */}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -7,7 +7,7 @@ import { useAuthStore } from '@/store/authStore';
 import { useSubscriptionStore } from '@/store/subscriptionStore';
 import { useFeatureBadgesStore } from '@/store/featureBadgesStore';
 import { Badge } from '@/components/ui/badge';
-import { Calendar, BarChart3, Clock, FileText, Calculator, BookOpen } from 'lucide-react';
+import { Calendar, BarChart3, Clock, FileText, Calculator, BookOpen, Layers } from 'lucide-react';
 import { WorkspaceSelector } from '@/components/workspace';
 import { UserMenu } from '@/components/layout/UserMenu';
 import { WelcomeOverlay, OnboardingTour } from '@/components/onboarding';
@@ -52,11 +52,12 @@ export function AppLayout() {
 
   // Mark features as seen when user visits them
   useEffect(() => {
-    const pathToFeature: Record<string, 'dashboard' | 'subjects' | 'allocation' | 'scratchpad'> = {
+    const pathToFeature: Record<string, 'dashboard' | 'subjects' | 'allocation' | 'scratchpad' | 'disciplines'> = {
       '/app/dashboard': 'dashboard',
       '/app/subjects': 'subjects',
       '/app/allocation': 'allocation',
       '/app/scratchpad': 'scratchpad',
+      '/app/disciplines': 'disciplines',
     };
     const feature = pathToFeature[location.pathname];
     if (feature && isFeatureNew(feature)) {
@@ -76,6 +77,7 @@ export function AppLayout() {
     { to: '/app/scratchpad', icon: FileText, label: 'Notas', badgeKey: 'scratchpad' as const, tourId: 'nav-scratchpad' },
     { to: '/app/dashboard', icon: BarChart3, label: 'Dashboard', badgeKey: 'dashboard' as const, tourId: 'nav-dashboard' },
     { to: '/app/subjects', icon: BookOpen, label: 'Tópicos', badgeKey: 'subjects' as const, tourId: 'nav-subjects' },
+    { to: '/app/disciplines', icon: Layers, label: 'Disciplinas', badgeKey: 'disciplines' as const, tourId: 'nav-disciplines' },
     { to: '/app/allocation', icon: Calculator, label: 'Alocação', badgeKey: 'allocation' as const, tourId: 'nav-allocation' },
   ];
 

--- a/frontend/src/components/study-cycle/CycleSuggestionCard.tsx
+++ b/frontend/src/components/study-cycle/CycleSuggestionCard.tsx
@@ -282,7 +282,12 @@ export function CycleSuggestionCard() {
           {/* Current subject */}
           <div>
             <div className="flex items-center justify-between mb-1">
-              <span className="text-sm font-medium truncate" title={data.currentSubject}>
+              <span className="text-sm font-medium truncate flex items-center gap-1.5" title={data.currentSubject}>
+                {data.currentIsDiscipline ? (
+                  <Layers className="h-3.5 w-3.5 text-primary/70 shrink-0" />
+                ) : (
+                  <BookOpen className="h-3.5 w-3.5 text-muted-foreground/70 shrink-0" />
+                )}
                 {data.currentSubject}
               </span>
               <span className="text-xs text-muted-foreground whitespace-nowrap ml-2">
@@ -409,8 +414,13 @@ export function CycleSuggestionCard() {
                         className={`p-2 rounded-md ${isCurrent ? 'bg-primary/10' : 'bg-muted/50'}`}
                       >
                         <div className="flex items-center justify-between mb-1">
-                          <span className={`text-xs truncate ${isCurrent ? 'font-medium' : ''}`} title={item.subject}>
-                            {item.isComplete && <Check className="h-3 w-3 inline mr-1 text-accent" />}
+                          <span className={`text-xs truncate flex items-center gap-1 ${isCurrent ? 'font-medium' : ''}`} title={item.subject}>
+                            {item.isComplete && <Check className="h-3 w-3 text-accent shrink-0" />}
+                            {item.isDiscipline ? (
+                              <Layers className="h-3 w-3 text-primary/70 shrink-0" />
+                            ) : (
+                              <BookOpen className="h-3 w-3 text-muted-foreground/50 shrink-0" />
+                            )}
                             {item.subject}
                           </span>
                           <span className="text-xs text-muted-foreground whitespace-nowrap ml-2">

--- a/frontend/src/components/study-cycle/SortableCycleItem.tsx
+++ b/frontend/src/components/study-cycle/SortableCycleItem.tsx
@@ -4,7 +4,7 @@
  */
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Trash2 } from 'lucide-react';
+import { GripVertical, Trash2, BookOpen, Layers } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
@@ -14,6 +14,7 @@ interface SortableCycleItemProps {
   subjectName: string;
   duration: string;
   onRemove: () => void;
+  isDiscipline?: boolean;
 }
 
 export function SortableCycleItem({
@@ -22,6 +23,7 @@ export function SortableCycleItem({
   subjectName,
   duration,
   onRemove,
+  isDiscipline = false,
 }: SortableCycleItemProps) {
   const {
     attributes,
@@ -59,6 +61,11 @@ export function SortableCycleItem({
       <span className="text-xs text-muted-foreground w-5">
         {index + 1}.
       </span>
+      {isDiscipline ? (
+        <Layers className="h-3.5 w-3.5 text-primary/70 shrink-0" />
+      ) : (
+        <BookOpen className="h-3.5 w-3.5 text-muted-foreground/70 shrink-0" />
+      )}
       <span className="flex-1 text-sm font-medium truncate">
         {subjectName}
       </span>

--- a/frontend/src/lib/api/disciplines.ts
+++ b/frontend/src/lib/api/disciplines.ts
@@ -1,0 +1,83 @@
+/**
+ * Disciplines API
+ */
+import { apiClient } from './client';
+import type {
+  Discipline,
+  CreateDisciplineDto,
+  UpdateDisciplineDto,
+} from '@/types/api';
+
+export const disciplinesApi = {
+  /**
+   * Get all disciplines for a workspace
+   */
+  async getAll(workspaceId: string): Promise<Discipline[]> {
+    return apiClient.get<Discipline[]>(`/api/workspaces/${workspaceId}/disciplines`);
+  },
+
+  /**
+   * Get a single discipline by ID
+   */
+  async getOne(disciplineId: string): Promise<Discipline> {
+    return apiClient.get<Discipline>(`/api/disciplines/${disciplineId}`);
+  },
+
+  /**
+   * Create a new discipline
+   */
+  async create(workspaceId: string, data: CreateDisciplineDto): Promise<Discipline> {
+    return apiClient.post<Discipline, CreateDisciplineDto>(
+      `/api/workspaces/${workspaceId}/disciplines`,
+      data,
+    );
+  },
+
+  /**
+   * Update a discipline
+   */
+  async update(disciplineId: string, data: UpdateDisciplineDto): Promise<Discipline> {
+    return apiClient.put<Discipline, UpdateDisciplineDto>(
+      `/api/disciplines/${disciplineId}`,
+      data,
+    );
+  },
+
+  /**
+   * Add subjects to a discipline
+   */
+  async addSubjects(disciplineId: string, subjectIds: string[]): Promise<Discipline> {
+    return apiClient.post<Discipline, { subjectIds: string[] }>(
+      `/api/disciplines/${disciplineId}/subjects`,
+      { subjectIds },
+    );
+  },
+
+  /**
+   * Remove subjects from a discipline
+   */
+  async removeSubjects(disciplineId: string, subjectIds: string[]): Promise<Discipline> {
+    return apiClient.delete<Discipline>(`/api/disciplines/${disciplineId}/subjects`, {
+      subjectIds,
+    });
+  },
+
+  /**
+   * Reorder disciplines
+   */
+  async reorder(workspaceId: string, orderedIds: string[]): Promise<Discipline[]> {
+    return apiClient.put<Discipline[], { orderedIds: string[] }>(
+      `/api/workspaces/${workspaceId}/disciplines/reorder`,
+      { orderedIds },
+    );
+  },
+
+  /**
+   * Delete a discipline
+   */
+  async delete(disciplineId: string): Promise<void> {
+    return apiClient.delete<void>(`/api/disciplines/${disciplineId}`);
+  },
+};
+
+export default disciplinesApi;

--- a/frontend/src/store/disciplineStore.ts
+++ b/frontend/src/store/disciplineStore.ts
@@ -1,0 +1,203 @@
+/**
+ * Discipline Store using Zustand
+ */
+import { create } from 'zustand';
+import type { Discipline, CreateDisciplineDto, UpdateDisciplineDto } from '@/types/api';
+import { disciplinesApi } from '@/lib/api/disciplines';
+
+interface DisciplineState {
+  disciplines: Discipline[];
+  isLoading: boolean;
+  isSaving: boolean;
+  error: string | null;
+  currentWorkspaceId: string | null;
+}
+
+interface DisciplineActions {
+  fetchDisciplines: (workspaceId: string) => Promise<void>;
+  createDiscipline: (workspaceId: string, data: CreateDisciplineDto) => Promise<Discipline>;
+  updateDiscipline: (disciplineId: string, data: UpdateDisciplineDto) => Promise<Discipline>;
+  addSubjectsToDiscipline: (disciplineId: string, subjectIds: string[]) => Promise<Discipline>;
+  removeSubjectsFromDiscipline: (disciplineId: string, subjectIds: string[]) => Promise<Discipline>;
+  reorderDisciplines: (workspaceId: string, orderedIds: string[]) => Promise<void>;
+  deleteDiscipline: (disciplineId: string) => Promise<void>;
+  getDisciplineById: (id: string) => Discipline | undefined;
+  getDisciplineByName: (name: string) => Discipline | undefined;
+  clearDisciplines: () => void;
+  setError: (error: string | null) => void;
+}
+
+type DisciplineStore = DisciplineState & DisciplineActions;
+
+export const useDisciplineStore = create<DisciplineStore>()((set, get) => ({
+  // Initial state
+  disciplines: [],
+  isLoading: false,
+  isSaving: false,
+  error: null,
+  currentWorkspaceId: null,
+
+  // Actions
+  fetchDisciplines: async (workspaceId) => {
+    try {
+      set({ isLoading: true, error: null, currentWorkspaceId: workspaceId });
+      const disciplines = await disciplinesApi.getAll(workspaceId);
+      set({ disciplines, isLoading: false });
+    } catch (error) {
+      set({
+        isLoading: false,
+        error: error instanceof Error ? error.message : 'Failed to fetch disciplines',
+      });
+      throw error;
+    }
+  },
+
+  createDiscipline: async (workspaceId, data) => {
+    try {
+      set({ isSaving: true, error: null });
+      const newDiscipline = await disciplinesApi.create(workspaceId, data);
+
+      set((state) => ({
+        disciplines: [...state.disciplines, newDiscipline].sort(
+          (a, b) => a.position - b.position
+        ),
+        isSaving: false,
+      }));
+
+      return newDiscipline;
+    } catch (error) {
+      set({
+        isSaving: false,
+        error: error instanceof Error ? error.message : 'Failed to create discipline',
+      });
+      throw error;
+    }
+  },
+
+  updateDiscipline: async (disciplineId, data) => {
+    try {
+      set({ isSaving: true, error: null });
+      const updatedDiscipline = await disciplinesApi.update(disciplineId, data);
+
+      set((state) => ({
+        disciplines: state.disciplines
+          .map((d) => (d.id === disciplineId ? updatedDiscipline : d))
+          .sort((a, b) => a.position - b.position),
+        isSaving: false,
+      }));
+
+      return updatedDiscipline;
+    } catch (error) {
+      set({
+        isSaving: false,
+        error: error instanceof Error ? error.message : 'Failed to update discipline',
+      });
+      throw error;
+    }
+  },
+
+  addSubjectsToDiscipline: async (disciplineId, subjectIds) => {
+    try {
+      set({ isSaving: true, error: null });
+      const updatedDiscipline = await disciplinesApi.addSubjects(disciplineId, subjectIds);
+
+      set((state) => ({
+        disciplines: state.disciplines.map((d) =>
+          d.id === disciplineId ? updatedDiscipline : d
+        ),
+        isSaving: false,
+      }));
+
+      return updatedDiscipline;
+    } catch (error) {
+      set({
+        isSaving: false,
+        error: error instanceof Error ? error.message : 'Failed to add subjects to discipline',
+      });
+      throw error;
+    }
+  },
+
+  removeSubjectsFromDiscipline: async (disciplineId, subjectIds) => {
+    try {
+      set({ isSaving: true, error: null });
+      const updatedDiscipline = await disciplinesApi.removeSubjects(disciplineId, subjectIds);
+
+      set((state) => ({
+        disciplines: state.disciplines.map((d) =>
+          d.id === disciplineId ? updatedDiscipline : d
+        ),
+        isSaving: false,
+      }));
+
+      return updatedDiscipline;
+    } catch (error) {
+      set({
+        isSaving: false,
+        error:
+          error instanceof Error ? error.message : 'Failed to remove subjects from discipline',
+      });
+      throw error;
+    }
+  },
+
+  reorderDisciplines: async (workspaceId, orderedIds) => {
+    try {
+      set({ isSaving: true, error: null });
+      const reorderedDisciplines = await disciplinesApi.reorder(workspaceId, orderedIds);
+
+      set({
+        disciplines: reorderedDisciplines,
+        isSaving: false,
+      });
+    } catch (error) {
+      set({
+        isSaving: false,
+        error: error instanceof Error ? error.message : 'Failed to reorder disciplines',
+      });
+      throw error;
+    }
+  },
+
+  deleteDiscipline: async (disciplineId) => {
+    try {
+      set({ isSaving: true, error: null });
+      await disciplinesApi.delete(disciplineId);
+
+      set((state) => ({
+        disciplines: state.disciplines.filter((d) => d.id !== disciplineId),
+        isSaving: false,
+      }));
+    } catch (error) {
+      set({
+        isSaving: false,
+        error: error instanceof Error ? error.message : 'Failed to delete discipline',
+      });
+      throw error;
+    }
+  },
+
+  getDisciplineById: (id) => {
+    return get().disciplines.find((d) => d.id === id);
+  },
+
+  getDisciplineByName: (name) => {
+    return get().disciplines.find(
+      (d) => d.name && d.name.toLowerCase() === name.toLowerCase()
+    );
+  },
+
+  clearDisciplines: () => {
+    set({
+      disciplines: [],
+      currentWorkspaceId: null,
+      error: null,
+    });
+  },
+
+  setError: (error) => {
+    set({ error });
+  },
+}));
+
+export default useDisciplineStore;

--- a/frontend/src/store/featureBadgesStore.ts
+++ b/frontend/src/store/featureBadgesStore.ts
@@ -5,7 +5,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-export type FeatureKey = 'timer' | 'cycles' | 'dashboard' | 'allocation' | 'subjects' | 'scratchpad';
+export type FeatureKey = 'timer' | 'cycles' | 'dashboard' | 'allocation' | 'subjects' | 'scratchpad' | 'disciplines';
 
 interface FeatureBadgesState {
   seenFeatures: Record<FeatureKey, boolean>;
@@ -28,6 +28,7 @@ const initialSeenFeatures: Record<FeatureKey, boolean> = {
   allocation: false,
   subjects: false,
   scratchpad: false,
+  disciplines: false,
 };
 
 export const useFeatureBadgesStore = create<FeatureBadgesStore>()(

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -50,11 +50,13 @@ export interface SubjectCategory {
 export interface Subject {
   id: string;
   workspaceId: string;
+  disciplineId: string | null;
   name: string;
   color: string | null;
   icon: string | null;
   category: string | null; // @deprecated - use categories
   categories: SubjectCategory[];
+  discipline?: Discipline | null;
   position: number;
   archivedAt: string | null;
   createdAt: string;
@@ -93,6 +95,40 @@ export interface UpdateCategoryDto {
   name?: string;
   color?: string;
   position?: number;
+}
+
+// Discipline entity - groups related subjects for study cycle organization
+export interface Discipline {
+  id: string;
+  workspaceId: string;
+  name: string;
+  color: string | null;
+  icon: string | null;
+  position: number;
+  subjects: Pick<Subject, 'id' | 'name' | 'color' | 'icon'>[];
+  createdAt: string;
+  updatedAt: string;
+  _count?: {
+    subjects: number;
+  };
+}
+
+// Create discipline DTO
+export interface CreateDisciplineDto {
+  name: string;
+  color?: string;
+  icon?: string;
+  position?: number;
+  subjectIds?: string[];
+}
+
+// Update discipline DTO
+export interface UpdateDisciplineDto {
+  name?: string;
+  color?: string;
+  icon?: string;
+  position?: number;
+  subjectIds?: string[];
 }
 
 // Merge subjects DTO
@@ -202,8 +238,10 @@ export interface UpdateWorkspaceDto {
 export interface StudyCycleItem {
   id: string;
   cycleId: string;
-  subjectId: string;
-  subject: Subject; // Populated relation
+  subjectId: string | null;
+  disciplineId: string | null;
+  subject: Subject | null; // Populated relation
+  discipline: Discipline | null; // Populated relation
   targetMinutes: number;
   position: number;
 }
@@ -227,6 +265,9 @@ export interface CycleItemProgress {
   accumulatedMinutes: number;
   isComplete: boolean;
   position: number;
+  isDiscipline: boolean;
+  disciplineId?: string;
+  subjectId?: string;
 }
 
 // Cycle Suggestion response
@@ -245,6 +286,9 @@ export interface CycleSuggestion {
     totalItems: number;
     allItemsProgress: CycleItemProgress[];
     isCycleComplete: boolean;
+    currentIsDiscipline: boolean;
+    currentDisciplineId?: string;
+    currentSubjectId?: string;
   } | null;
 }
 
@@ -281,7 +325,8 @@ export interface CycleHistory {
 
 // Create cycle item DTO
 export interface CreateCycleItemDto {
-  subjectId: string;
+  subjectId?: string;
+  disciplineId?: string;
   targetMinutes: number;
 }
 

--- a/frontend/src/views/DisciplinesPage.tsx
+++ b/frontend/src/views/DisciplinesPage.tsx
@@ -1,0 +1,471 @@
+/**
+ * Disciplines Management Page
+ * Manage disciplines that group related subjects for study cycles
+ */
+import { useState, useEffect } from 'react';
+import { useDisciplineStore } from '@/store/disciplineStore';
+import { useSubjectStore } from '@/store/subjectStore';
+import { useWorkspaceStore } from '@/store/workspaceStore';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import {
+  Layers,
+  Plus,
+  Pencil,
+  Trash2,
+  Loader2,
+  Check,
+  X,
+  BookOpen,
+  ChevronDown,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+
+// Color palette for disciplines
+const COLOR_OPTIONS = [
+  '#ef4444', // red
+  '#f97316', // orange
+  '#eab308', // yellow
+  '#22c55e', // green
+  '#14b8a6', // teal
+  '#3b82f6', // blue
+  '#8b5cf6', // violet
+  '#ec4899', // pink
+  '#6b7280', // gray
+  null, // no color
+];
+
+interface EditingDiscipline {
+  id: string;
+  name: string;
+  color: string | null;
+}
+
+export function DisciplinesPage() {
+  const { workspaces, currentWorkspaceId } = useWorkspaceStore();
+  const currentWorkspace = workspaces.find((w) => w.id === currentWorkspaceId) || null;
+  const {
+    disciplines,
+    isLoading,
+    isSaving,
+    error,
+    fetchDisciplines,
+    createDiscipline,
+    updateDiscipline,
+    addSubjectsToDiscipline,
+    removeSubjectsFromDiscipline,
+    deleteDiscipline,
+    setError,
+  } = useDisciplineStore();
+
+  const { subjects, fetchSubjects, getActiveSubjects } = useSubjectStore();
+  const activeSubjects = getActiveSubjects();
+
+  const [newDisciplineName, setNewDisciplineName] = useState('');
+  const [editingDiscipline, setEditingDiscipline] = useState<EditingDiscipline | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [expandedDisciplines, setExpandedDisciplines] = useState<Set<string>>(new Set());
+  const [addingSubjectTo, setAddingSubjectTo] = useState<string | null>(null);
+
+  // Fetch disciplines and subjects when workspace changes
+  useEffect(() => {
+    if (currentWorkspace) {
+      fetchDisciplines(currentWorkspace.id);
+      fetchSubjects(currentWorkspace.id);
+    }
+  }, [currentWorkspace, fetchDisciplines, fetchSubjects]);
+
+  // Handle create new discipline
+  const handleCreate = async () => {
+    if (!currentWorkspace || !newDisciplineName.trim()) return;
+    try {
+      await createDiscipline(currentWorkspace.id, { name: newDisciplineName.trim() });
+      setNewDisciplineName('');
+    } catch {
+      // Error is handled in store
+    }
+  };
+
+  // Handle start editing
+  const handleStartEdit = (discipline: { id: string; name: string; color: string | null }) => {
+    setEditingDiscipline({
+      id: discipline.id,
+      name: discipline.name,
+      color: discipline.color,
+    });
+  };
+
+  // Handle save edit
+  const handleSaveEdit = async () => {
+    if (!editingDiscipline) return;
+    try {
+      await updateDiscipline(editingDiscipline.id, {
+        name: editingDiscipline.name,
+        color: editingDiscipline.color ?? undefined,
+      });
+      setEditingDiscipline(null);
+    } catch {
+      // Error is handled in store
+    }
+  };
+
+  // Handle delete
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteDiscipline(id);
+      setConfirmDelete(null);
+    } catch {
+      // Error is handled in store
+    }
+  };
+
+  // Handle add subject to discipline
+  const handleAddSubject = async (disciplineId: string, subjectId: string) => {
+    try {
+      await addSubjectsToDiscipline(disciplineId, [subjectId]);
+      setAddingSubjectTo(null);
+    } catch {
+      // Error is handled in store
+    }
+  };
+
+  // Handle remove subject from discipline
+  const handleRemoveSubject = async (disciplineId: string, subjectId: string) => {
+    try {
+      await removeSubjectsFromDiscipline(disciplineId, [subjectId]);
+    } catch {
+      // Error is handled in store
+    }
+  };
+
+  // Toggle expanded state
+  const toggleExpanded = (id: string) => {
+    setExpandedDisciplines((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  // Get subjects not in any discipline (or in current discipline)
+  const getAvailableSubjects = (currentDisciplineId: string) => {
+    const disciplineSubjectIds = new Set(
+      disciplines
+        .filter((d) => d.id !== currentDisciplineId)
+        .flatMap((d) => d.subjects.map((s) => s.id))
+    );
+    return activeSubjects.filter((s) => !disciplineSubjectIds.has(s.id));
+  };
+
+  if (!currentWorkspace) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <Layers className="h-12 w-12 text-muted-foreground mb-4" />
+        <h2 className="text-xl font-semibold mb-2">Nenhum workspace selecionado</h2>
+        <p className="text-muted-foreground">
+          Selecione um workspace para gerenciar as disciplinas.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold">Disciplinas</h1>
+        <p className="text-muted-foreground">
+          Agrupe tópicos relacionados em disciplinas para usar no ciclo de estudos
+        </p>
+      </div>
+
+      {/* Error message */}
+      {error && (
+        <div className="bg-destructive/10 text-destructive p-4 rounded-lg flex items-center justify-between">
+          <span>{error}</span>
+          <Button variant="ghost" size="sm" onClick={() => setError(null)}>
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+
+      {/* Add new discipline */}
+      <div className="flex gap-2">
+        <Input
+          placeholder="Nome da nova disciplina..."
+          value={newDisciplineName}
+          onChange={(e) => setNewDisciplineName(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+          disabled={isSaving}
+          className="max-w-md"
+        />
+        <Button onClick={handleCreate} disabled={!newDisciplineName.trim() || isSaving}>
+          {isSaving ? (
+            <Loader2 className="h-4 w-4 animate-spin mr-2" />
+          ) : (
+            <Plus className="h-4 w-4 mr-2" />
+          )}
+          Adicionar
+        </Button>
+      </div>
+
+      {/* Disciplines list */}
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      ) : disciplines.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-12 text-center border-2 border-dashed rounded-lg">
+          <Layers className="h-12 w-12 text-muted-foreground mb-4" />
+          <h3 className="text-lg font-medium mb-2">Nenhuma disciplina cadastrada</h3>
+          <p className="text-muted-foreground mb-4">
+            Crie disciplinas para agrupar tópicos relacionados.
+            <br />
+            Ex: "Inglês" pode conter "Listening", "Grammar", "Reading"
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {disciplines.map((discipline) => {
+            const isEditing = editingDiscipline?.id === discipline.id;
+            const isExpanded = expandedDisciplines.has(discipline.id);
+            const availableSubjects = getAvailableSubjects(discipline.id);
+            const unassignedSubjects = availableSubjects.filter(
+              (s) => !discipline.subjects.some((ds) => ds.id === s.id)
+            );
+
+            return (
+              <Collapsible
+                key={discipline.id}
+                open={isExpanded}
+                onOpenChange={() => toggleExpanded(discipline.id)}
+              >
+                <div className="border rounded-lg overflow-hidden">
+                  {/* Discipline header */}
+                  <div
+                    className={cn(
+                      'flex items-center gap-3 p-3 bg-muted/30',
+                      isExpanded && 'border-b'
+                    )}
+                  >
+                    <CollapsibleTrigger asChild>
+                      <Button variant="ghost" size="icon" className="h-8 w-8">
+                        <ChevronDown
+                          className={cn(
+                            'h-4 w-4 transition-transform',
+                            isExpanded && 'rotate-180'
+                          )}
+                        />
+                      </Button>
+                    </CollapsibleTrigger>
+
+                    {/* Color indicator */}
+                    {isEditing ? (
+                      <div className="flex gap-1">
+                        {COLOR_OPTIONS.map((color, i) => (
+                          <button
+                            key={i}
+                            onClick={() =>
+                              setEditingDiscipline({ ...editingDiscipline!, color })
+                            }
+                            className={cn(
+                              'w-5 h-5 rounded-full border-2 transition-transform hover:scale-110',
+                              editingDiscipline?.color === color &&
+                                'ring-2 ring-offset-2 ring-primary'
+                            )}
+                            style={{ backgroundColor: color || 'transparent' }}
+                          >
+                            {color === null && (
+                              <X className="h-3 w-3 mx-auto text-muted-foreground" />
+                            )}
+                          </button>
+                        ))}
+                      </div>
+                    ) : (
+                      <span
+                        className="w-4 h-4 rounded-full shrink-0"
+                        style={{ backgroundColor: discipline.color || '#6b7280' }}
+                      />
+                    )}
+
+                    {/* Name */}
+                    {isEditing ? (
+                      <Input
+                        value={editingDiscipline?.name || ''}
+                        onChange={(e) =>
+                          setEditingDiscipline({ ...editingDiscipline!, name: e.target.value })
+                        }
+                        className="flex-1 h-8"
+                        placeholder="Nome"
+                        autoFocus
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') handleSaveEdit();
+                          if (e.key === 'Escape') setEditingDiscipline(null);
+                        }}
+                      />
+                    ) : (
+                      <span className="flex-1 font-medium">{discipline.name}</span>
+                    )}
+
+                    {/* Subject count */}
+                    <Badge variant="secondary" className="text-xs">
+                      {discipline.subjects.length} tópicos
+                    </Badge>
+
+                    {/* Actions */}
+                    <div className="flex items-center gap-1">
+                      {isEditing ? (
+                        <>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            onClick={handleSaveEdit}
+                            disabled={isSaving}
+                          >
+                            <Check className="h-4 w-4 text-green-600" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            onClick={() => setEditingDiscipline(null)}
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </>
+                      ) : (
+                        <>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            onClick={() => handleStartEdit(discipline)}
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8 text-destructive hover:text-destructive"
+                            onClick={() => setConfirmDelete(discipline.id)}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Subjects list */}
+                  <CollapsibleContent>
+                    <div className="p-3 space-y-2">
+                      {discipline.subjects.length === 0 ? (
+                        <p className="text-sm text-muted-foreground text-center py-2">
+                          Nenhum tópico vinculado a esta disciplina
+                        </p>
+                      ) : (
+                        <div className="space-y-1">
+                          {discipline.subjects.map((subject) => (
+                            <div
+                              key={subject.id}
+                              className="flex items-center gap-2 p-2 rounded-md bg-muted/50"
+                            >
+                              <BookOpen className="h-3.5 w-3.5 text-muted-foreground" />
+                              <span className="flex-1 text-sm">{subject.name}</span>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-6 w-6 text-muted-foreground hover:text-destructive"
+                                onClick={() => handleRemoveSubject(discipline.id, subject.id)}
+                              >
+                                <X className="h-3 w-3" />
+                              </Button>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+
+                      {/* Add subject */}
+                      {addingSubjectTo === discipline.id ? (
+                        <div className="space-y-2 pt-2 border-t">
+                          <p className="text-xs text-muted-foreground">
+                            Selecione um tópico para adicionar:
+                          </p>
+                          <div className="flex flex-wrap gap-1">
+                            {unassignedSubjects.length === 0 ? (
+                              <p className="text-xs text-muted-foreground">
+                                Todos os tópicos já estão em disciplinas
+                              </p>
+                            ) : (
+                              unassignedSubjects.map((subject) => (
+                                <Button
+                                  key={subject.id}
+                                  variant="outline"
+                                  size="sm"
+                                  className="h-7 text-xs"
+                                  onClick={() => handleAddSubject(discipline.id, subject.id)}
+                                >
+                                  <Plus className="h-3 w-3 mr-1" />
+                                  {subject.name}
+                                </Button>
+                              ))
+                            )}
+                          </div>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setAddingSubjectTo(null)}
+                          >
+                            Cancelar
+                          </Button>
+                        </div>
+                      ) : (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="w-full"
+                          onClick={() => setAddingSubjectTo(discipline.id)}
+                        >
+                          <Plus className="h-3.5 w-3.5 mr-1.5" />
+                          Adicionar tópico
+                        </Button>
+                      )}
+                    </div>
+                  </CollapsibleContent>
+                </div>
+              </Collapsible>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Delete confirmation dialog */}
+      <ConfirmDialog
+        open={!!confirmDelete}
+        onOpenChange={(open) => !open && setConfirmDelete(null)}
+        title="Deletar disciplina?"
+        description="A disciplina será removida permanentemente. Os tópicos não serão afetados, apenas perderão o vínculo com esta disciplina."
+        confirmText="Deletar"
+        variant="destructive"
+        onConfirm={() => {
+          if (confirmDelete) handleDelete(confirmDelete);
+        }}
+        isLoading={isSaving}
+      />
+    </div>
+  );
+}
+
+export default DisciplinesPage;


### PR DESCRIPTION
- Add Discipline model to Prisma schema with subjects relation
- Create discipline NestJS module (service, controller, DTOs)
- Update StudyCycleItem to support both Subject and Discipline
- Update StudyCycle service to aggregate minutes from discipline subjects
- Add frontend types, API client, and Zustand store for disciplines
- Update CycleEditorModal to allow adding disciplines to cycles
- Update CycleSuggestionCard to show discipline icons
- Create DisciplinesPage for managing disciplines
- Add disciplines route and navigation

This allows users to group related subjects (e.g., "Listening", "Grammar")
under a discipline (e.g., "English") and track study time at the
discipline level in cycles, while still recording sessions per subject.

https://claude.ai/code/session_01DZcWuNvRYkffv1mg795CA6